### PR TITLE
Update groovy templates to avoid flex compilation warning

### DIFF
--- a/src/org/granite/generator/template/bean.gsp
+++ b/src/org/granite/generator/template/bean.gsp
@@ -48,7 +48,11 @@ package ${jClass.as3Type.packageName} {<%
 
     [Bindable]
     [RemoteClass(alias="${jClass.qualifiedName}")]
-    public class ${jClass.as3Type.name} extends ${jClass.as3Type.name}Base {<%
+    public class ${jClass.as3Type.name} extends ${jClass.as3Type.name}Base {
+
+        public function ${jClass.as3Type.name}(){
+            super();
+        } <%
 
     ///////////////////////////////////////////////////////////////////////////
     // (Re)Write Public Getters/Setters for Implemented Interfaces.

--- a/src/org/granite/generator/template/beanBase.gsp
+++ b/src/org/granite/generator/template/beanBase.gsp
@@ -83,7 +83,11 @@ package ${jClass.as3Type.packageName} {
         }
 
     %> {
-<%
+<%  if (jClass.superclass!=null || jClass.as3Superclass!=null){%>
+
+        public function ${jClass.as3Type.name}Base(){
+            super();
+        }<% }
 
     ///////////////////////////////////////////////////////////////////////////
     // Write Private Fields.

--- a/src/org/granite/generator/template/beanBase.gsp
+++ b/src/org/granite/generator/template/beanBase.gsp
@@ -83,12 +83,14 @@ package ${jClass.as3Type.packageName} {
         }
 
     %> {
-<%  if (jClass.superclass!=null || jClass.as3Superclass!=null){%>
+
 
         public function ${jClass.as3Type.name}Base(){
+<%  if (jClass.superclass!=null || jClass.as3Superclass!=null){%>
             super();
-        }<% }
-
+<% } %>
+        }
+<%
     ///////////////////////////////////////////////////////////////////////////
     // Write Private Fields.
 

--- a/src/org/granite/generator/template/entity.gsp
+++ b/src/org/granite/generator/template/entity.gsp
@@ -48,7 +48,12 @@ package ${jClass.as3Type.packageName} {<%
 
     [Bindable]
     [RemoteClass(alias="${jClass.qualifiedName}")]
-    public class ${jClass.as3Type.name} extends ${jClass.as3Type.name}Base {<%
+    public class ${jClass.as3Type.name} extends ${jClass.as3Type.name}Base {
+
+
+        public function ${jClass.as3Type.name}(){
+            super();
+        } <%
 
     ///////////////////////////////////////////////////////////////////////////
     // (Re)Write Public Getters/Setters for Implemented Interfaces.

--- a/src/org/granite/generator/template/entityBase.gsp
+++ b/src/org/granite/generator/template/entityBase.gsp
@@ -90,7 +90,11 @@ package ${jClass.as3Type.packageName} {
         }
 
     %> {
-<%
+<%  if (jClass.superclass!=null || jClass.as3Superclass!=null){%>
+
+        public function ${jClass.as3Type.name}Base(){
+            super();
+        }<% }
 
     ///////////////////////////////////////////////////////////////////////////
     // Write Private Fields.

--- a/src/org/granite/generator/template/entityBase.gsp
+++ b/src/org/granite/generator/template/entityBase.gsp
@@ -90,12 +90,14 @@ package ${jClass.as3Type.packageName} {
         }
 
     %> {
-<%  if (jClass.superclass!=null || jClass.as3Superclass!=null){%>
+
 
         public function ${jClass.as3Type.name}Base(){
+<%  if (jClass.superclass!=null || jClass.as3Superclass!=null){%>
             super();
-        }<% }
-
+<% } %>
+        }
+<%
     ///////////////////////////////////////////////////////////////////////////
     // Write Private Fields.
 

--- a/src/org/granite/generator/template/enum.gsp
+++ b/src/org/granite/generator/template/enum.gsp
@@ -32,10 +32,7 @@ package ${jClass.as3Type.packageName} {
     [Bindable]
     [RemoteClass(alias="${jClass.qualifiedName}")]
     public class ${jClass.as3Type.name} extends Enum {
-
-        public function ${jClass.as3Type.name}(){
-            super();
-        } <%
+    <%
 
         for (jEnumValue in jClass.enumValues) {%>
         public static const ${jEnumValue.name}:${jClass.name} = new ${jClass.name}("${jEnumValue.name}", _);<%

--- a/src/org/granite/generator/template/enum.gsp
+++ b/src/org/granite/generator/template/enum.gsp
@@ -32,7 +32,10 @@ package ${jClass.as3Type.packageName} {
     [Bindable]
     [RemoteClass(alias="${jClass.qualifiedName}")]
     public class ${jClass.as3Type.name} extends Enum {
-<%
+
+        public function ${jClass.as3Type.name}(){
+            super();
+        } <%
 
         for (jEnumValue in jClass.enumValues) {%>
         public static const ${jEnumValue.name}:${jClass.name} = new ${jClass.name}("${jEnumValue.name}", _);<%

--- a/src/org/granite/generator/template/lcdsBeanBase.gsp
+++ b/src/org/granite/generator/template/lcdsBeanBase.gsp
@@ -81,11 +81,13 @@ package ${jClass.as3Type.packageName} {
             }
         }
     %> {
-<%  if (jClass.superclass!=null || jClass.as3Superclass!=null){%>
-
+    
         public function ${jClass.as3Type.name}Base(){
+<%  if (jClass.superclass!=null || jClass.as3Superclass!=null){%>
             super();
-        }<% }
+<% } %>
+        }
+<%
 
     ///////////////////////////////////////////////////////////////////////////
     // Write Private Fields.

--- a/src/org/granite/generator/template/lcdsBeanBase.gsp
+++ b/src/org/granite/generator/template/lcdsBeanBase.gsp
@@ -81,7 +81,11 @@ package ${jClass.as3Type.packageName} {
             }
         }
     %> {
-<%
+<%  if (jClass.superclass!=null || jClass.as3Superclass!=null){%>
+
+        public function ${jClass.as3Type.name}Base(){
+            super();
+        }<% }
 
     ///////////////////////////////////////////////////////////////////////////
     // Write Private Fields.

--- a/src/org/granite/generator/template/lcdsStandaloneBean.gsp
+++ b/src/org/granite/generator/template/lcdsStandaloneBean.gsp
@@ -82,7 +82,10 @@ package ${jClass.as3Type.packageName} {
             }
         }
     %> {
-<%
+<%  if (jClass.superclass!=null || jClass.as3Superclass!=null){%>
+        public function ${jClass.as3Type.name}Base(){
+            super();
+        }<% }
 
     ///////////////////////////////////////////////////////////////////////////
     // Write Private Fields.

--- a/src/org/granite/generator/template/lcdsStandaloneBean.gsp
+++ b/src/org/granite/generator/template/lcdsStandaloneBean.gsp
@@ -83,7 +83,7 @@ package ${jClass.as3Type.packageName} {
         }
     %> {
 <%  if (jClass.superclass!=null || jClass.as3Superclass!=null){%>
-        public function ${jClass.as3Type.name}Base(){
+        public function ${jClass.as3Type.name}(){
             super();
         }<% }
 

--- a/src/org/granite/generator/template/remote.gsp
+++ b/src/org/granite/generator/template/remote.gsp
@@ -29,6 +29,9 @@ package ${jClass.as3Type.packageName} {
 
     [RemoteClass(alias="${jClass.qualifiedName}")]
     public class ${jClass.as3Type.name} extends ${jClass.as3Type.name}Base {
+        public function ${jClass.as3Type.name}(){
+            super();
+        }
     }
     
 }

--- a/src/org/granite/generator/template/remoteBase.gsp
+++ b/src/org/granite/generator/template/remoteBase.gsp
@@ -61,7 +61,12 @@ package ${jClass.as3Type.packageName} {
             %> extends RemoteObject<%
         }
 
-    %> {<%
+    %> {
+
+        public function ${jClass.as3Type.name}Base(){
+            super();
+        }
+<%
 
 ///////////////////////////////////////////////////////////////////////////
 // Write private "initialized?" flag declaration.%>

--- a/src/org/granite/generator/template/tideBeanBase.gsp
+++ b/src/org/granite/generator/template/tideBeanBase.gsp
@@ -84,11 +84,12 @@ package ${jClass.as3Type.packageName} {
         }
 
     %> {
-<%  if (jClass.superclass!=null || jClass.as3Superclass!=null){%>
-
         public function ${jClass.as3Type.name}Base(){
+<%  if (jClass.superclass!=null || jClass.as3Superclass!=null){%>
             super();
-        }<% }
+<% } %>
+        }
+<%
 
     ///////////////////////////////////////////////////////////////////////////
     // Write Private Fields.

--- a/src/org/granite/generator/template/tideBeanBase.gsp
+++ b/src/org/granite/generator/template/tideBeanBase.gsp
@@ -84,7 +84,11 @@ package ${jClass.as3Type.packageName} {
         }
 
     %> {
-<%
+<%  if (jClass.superclass!=null || jClass.as3Superclass!=null){%>
+
+        public function ${jClass.as3Type.name}Base(){
+            super();
+        }<% }
 
     ///////////////////////////////////////////////////////////////////////////
     // Write Private Fields.

--- a/src/org/granite/generator/template/tideEntityBase.gsp
+++ b/src/org/granite/generator/template/tideEntityBase.gsp
@@ -140,9 +140,14 @@ package ${jClass.as3Type.packageName} {
         }
 
     %> {
-<%
+<%  if (jClass.hasSuperclass()){%>
 
-    ///////////////////////////////////////////////////////////////////////////
+        public function ${jClass.as3Type.name}Base(){
+            super();
+        }<% }
+
+
+///////////////////////////////////////////////////////////////////////////
     // Write Private Fields.
 
     if (jClass.hasIdentifiers()) {%>

--- a/src/org/granite/generator/template/tideEntityBase.gsp
+++ b/src/org/granite/generator/template/tideEntityBase.gsp
@@ -140,13 +140,15 @@ package ${jClass.as3Type.packageName} {
         }
 
     %> {
-<%  if (jClass.hasSuperclass()){%>
+
 
         public function ${jClass.as3Type.name}Base(){
+        <%  if (jClass.hasSuperclass()){%>
             super();
-        }<% }
+        <% } %>
+        }
 
-
+<%
 ///////////////////////////////////////////////////////////////////////////
     // Write Private Fields.
 

--- a/src/org/granite/generator/template/tideRemoteBase.gsp
+++ b/src/org/granite/generator/template/tideRemoteBase.gsp
@@ -64,7 +64,7 @@ package ${jClass.as3Type.packageName} {
             %> extends Component {<%
         }%>
 
-        public function ${jClass.as3Type.name}(){
+        public function ${jClass.as3Type.name}Base(){
             super();
         }
 <%

--- a/src/org/granite/generator/template/tideRemoteBase.gsp
+++ b/src/org/granite/generator/template/tideRemoteBase.gsp
@@ -62,8 +62,12 @@ package ${jClass.as3Type.packageName} {
             %> extends ${jClass.superclass.as3Type.name} {<%
         } else {
             %> extends Component {<%
+        }%>
+
+        public function ${jClass.as3Type.name}(){
+            super();
         }
-                
+<%
 ///////////////////////////////////////////////////////////////////////////
 // Write Public Getter/Setter.
 


### PR DESCRIPTION
This patch ensures that graniteds generated classes have a default no-arg constructor to avoid having a warning in generated sources since the flex compiler will raise a warning on files which don't have any constructor.

The generated files either have an empty no-arg constructor or call `super()` when inheriting from another class.

With [jeanlaurent](https://github.com/jeanlaurent) we updated my inital attempt and ensured it works in as many cases as we could test.

All tests were done manually.
